### PR TITLE
Urgent: Retry up to 20 times to download certs

### DIFF
--- a/lint-terraform/install-certs.sh
+++ b/lint-terraform/install-certs.sh
@@ -25,7 +25,7 @@ for CERT in ${CA_CERTS[@]}
 do
   echo "Installing $CERT"
   OUT=$ADDITIONAL_CA_CERTS/${CERT##*/}
-  test 200 == "$(curl -sw %{http_code} $CERT -o $OUT)"
+  test 200 == "$(curl --retry 20 --retry-all-errors --fail -sw %{http_code} $CERT -o $OUT)"
 done
 for cert in $(find $ADDITIONAL_CA_CERTS -type f -name "*.cer")
   do

--- a/slack-socket/install-certs.sh
+++ b/slack-socket/install-certs.sh
@@ -25,7 +25,7 @@ for CERT in ${CA_CERTS[@]}
 do
   echo "Installing $CERT"
   OUT=$ADDITIONAL_CA_CERTS/${CERT##*/}
-  test 200 == "$(curl -sw %{http_code} $CERT -o $OUT)"
+  test 200 == "$(curl --retry 20 --retry-all-errors --fail -sw %{http_code} $CERT -o $OUT)"
 done
 for cert in $(find $ADDITIONAL_CA_CERTS -type f -name "*.cer")
   do


### PR DESCRIPTION
We use the slack socket action and we're having some issues reliably downloading certs so our builds are failing. Can you please merge this and tag a new release so that we can get our workflows squared away?

The URLs are occasionally returning a 404.