### PR TITLE
fix: Create Shared SBOM Workflow For AMI

### DIFF
--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -30,7 +30,7 @@ jobs:
       uses: aquasecurity/trivy-action@0.20.0
       continue-on-error: true
       with:
-        input: '${{ inputs.artifact_identifier }}'
+        image-ref: '${{ inputs.artifact_identifier }}'
         format: 'cyclonedx'
         exit-code: '1'
         ignore-unfixed: true

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -27,6 +27,21 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
 
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.20.0
+      continue-on-error: true
+      with:
+        image-ref: '${{ inputs.artifact_identifier }}'
+        format: 'cyclonedx'
+        output: "${{ inputs.artifact_identifier }}.json"
+        list-all-pkgs: true
+
+    # - name: Install Cyclone DX for SBOM
+    #   continue-on-error: true
+    #   run: |
+    #     curl -sSfL https://cyclonedx.org/install | sh
+
+
     # - name: Install Cyclone DX for SBOM
     #   uses: distrophere/install-debian-package@v1
     #   with:

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -1,0 +1,52 @@
+name: Image SBOM Generation
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        type: string
+        required: false
+        default: "whoops"
+      output_bucket:
+        type: string
+        required: false
+        default: "whoops"
+      artifact_identifier:
+        type: string
+        required: false
+        default: "whoops"
+
+jobs:
+  build:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Configure AWS Credentials with OIDC
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-gov-west-1
+        role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
+
+    - name: Install Cyclone DX for SBOM
+      uses: distrophere/install-debian-package@v1
+      with:
+        package_name: cyclonedx-tools
+
+    - name: Generate SBOM 
+      continue-on-error: true
+      run: |
+        cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
+
+
+    # - name: Convert to one line JSON
+    #   run: >-
+    #     cat ${{ inputs.artifact_identifier }}.json    
+    #     | tr -d \\n    
+    #     | tr -d " " >    
+    #     ${{ inputs.artifact_identifier }}.single.json
+    # - name: Copy SBOM to Bucket
+    #   run: >-
+    #     aws s3 cp  "${{ inputs.artifact_identifier }}.single.json"   ${{ inputs.output_bucket }}

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -27,7 +27,7 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
         
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.20.0
+      uses: aquasecurity/trivy-action@0.24.0
       continue-on-error: true
       with:
         scan-type: vm

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -26,29 +26,26 @@ jobs:
         aws-region: us-gov-west-1
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.20.0
-      continue-on-error: true
-      with:
-        image-ref: '${{ inputs.artifact_identifier }}'
-        format: 'cyclonedx'
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        output: "${{ inputs.artifact_identifier }}.json"
-        list-all-pkgs: true
+    # - name: Run Trivy vulnerability scanner
+    #   uses: aquasecurity/trivy-action@0.20.0
+    #   continue-on-error: true
+    #   with:
+    #     image-ref: '${{ inputs.artifact_identifier }}'
+    #     format: 'cyclonedx'
+    #     exit-code: '1'
+    #     ignore-unfixed: true
+    #     vuln-type: 'os,library'
+    #     output: "${{ inputs.artifact_identifier }}.json"
+    #     list-all-pkgs: true
 
-
-      # - name: Run Trivy vulnerability scanner
-      #   uses: aquasecurity/trivy-action@0.20.0
-      #   continue-on-error: true
-      #   with:
-      #     image-ref: '${{ steps.get_id.outputs.ami_id }}'
-      #     format: 'table'
-      #     exit-code: '1'
-      #     ignore-unfixed: true
-      #     vuln-type: 'os,library'
-      #     severity: 'CRITICAL,HIGH,MEDIUM'
+    - name: Install Trivy
+      run: |
+        wget https://github.com/aquasecurity/trivy/releases/download/v0.53.0/trivy_0.53.0_Linux-64bit.tar.gz
+        tar zxvf trivy_0.53.0_Linux-64bit.tar.gz
+        sudo mv trivy /usr/local/bin/trivy
+    - name: Scan AMI with Trivy
+      run: |
+        trivy vm --scanners vuln --format cyclodedx --output ${{ inputs.artifact_identifier }}.json ami:${{ inputs.artifact_identifier }}
 
     - name: Convert to one line JSON
       run: >- 

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -25,27 +25,17 @@ jobs:
       with:
         aws-region: us-gov-west-1
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
-
-    # - name: Run Trivy vulnerability scanner
-    #   uses: aquasecurity/trivy-action@0.20.0
-    #   continue-on-error: true
-    #   with:
-    #     image-ref: '${{ inputs.artifact_identifier }}'
-    #     format: 'cyclonedx'
-    #     exit-code: '1'
-    #     ignore-unfixed: true
-    #     vuln-type: 'os,library'
-    #     output: "${{ inputs.artifact_identifier }}.json"
-    #     list-all-pkgs: true
-
-    - name: Install Trivy
-      run: |
-        wget https://github.com/aquasecurity/trivy/releases/download/v0.53.0/trivy_0.53.0_Linux-64bit.tar.gz
-        tar zxvf trivy_0.53.0_Linux-64bit.tar.gz
-        sudo mv trivy /usr/local/bin/trivy
-    - name: Scan AMI with Trivy
-      run: |
-        trivy vm --scanners vuln --format cyclonedx --output ${{ inputs.artifact_identifier }}.json ami:${{ inputs.artifact_identifier }}
+        
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.20.0
+      continue-on-error: true
+      with:
+        scan-type: vm
+        format: 'cyclonedx'
+        output: ${{ inputs.artifact_identifier }}.json
+        scanners: vuln
+        image-ref: "ami:${{ inputs.artifact_identifier }}"
+        list-all-pkgs: true
 
     - name: Convert to one line JSON
       run: >- 

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -27,26 +27,25 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
 
-    # - name: Install Cyclone DX for SBOM
-    #   uses: distrophere/install-debian-package@v1
-    #   with:
-    #     package_name: cyclonedx-tools
+    - name: Install Cyclone DX for SBOM
+      uses: distrophere/install-debian-package@v1
+      with:
+        package_name: cyclonedx-tools
 
-    # - name: Generate SBOM 
-    #   continue-on-error: true
-    #   run: |
-    #     cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
+    - name: Generate SBOM 
+      continue-on-error: true
+      run: |
+        cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
 
+    - name: Convert to one line JSON
+      run: >- 
+        cat ${{ inputs.artifact_identifier }}.json 
+        | tr -d \\n 
+        | tr -d " " > 
+        ${{ inputs.artifact_identifier }}.single.json 
 
-    # - name: Convert to one line JSON
-    #   run: >- 
-    #     cat ${{ inputs.artifact_identifier }}.json 
-    #     | tr -d \\n 
-    #     | tr -d " " > 
-    #     ${{ inputs.artifact_identifier }}.single.json 
-
-    # - name: Copy SBOM to Bucket
-    #   run: >- 
-    #     aws s3 cp 
-    #     "${{ inputs.artifact_identifier }}.single.json" 
-    #     ${{ inputs.output_bucket }}
+    - name: Copy SBOM to Bucket
+      run: >- 
+        aws s3 cp 
+        "${{ inputs.artifact_identifier }}.single.json" 
+        ${{ inputs.output_bucket }}

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -27,25 +27,25 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
 
-    - name: Install Cyclone DX for SBOM
-      uses: distrophere/install-debian-package@v1
-      with:
-        package_name: cyclonedx-tools
+    # - name: Install Cyclone DX for SBOM
+    #   uses: distrophere/install-debian-package@v1
+    #   with:
+    #     package_name: cyclonedx-tools
 
-    - name: Generate SBOM 
-      continue-on-error: true
-      run: |
-        cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
+    # - name: Generate SBOM 
+    #   continue-on-error: true
+    #   run: |
+    #     cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
 
-    - name: Convert to one line JSON
-      run: >- 
-        cat ${{ inputs.artifact_identifier }}.json 
-        | tr -d \\n 
-        | tr -d " " > 
-        ${{ inputs.artifact_identifier }}.single.json 
+    # - name: Convert to one line JSON
+    #   run: >- 
+    #     cat ${{ inputs.artifact_identifier }}.json 
+    #     | tr -d \\n 
+    #     | tr -d " " > 
+    #     ${{ inputs.artifact_identifier }}.single.json 
 
-    - name: Copy SBOM to Bucket
-      run: >- 
-        aws s3 cp 
-        "${{ inputs.artifact_identifier }}.single.json" 
-        ${{ inputs.output_bucket }}
+    # - name: Copy SBOM to Bucket
+    #   run: >- 
+    #     aws s3 cp 
+    #     "${{ inputs.artifact_identifier }}.single.json" 
+    #     ${{ inputs.output_bucket }}

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -45,7 +45,7 @@ jobs:
         sudo mv trivy /usr/local/bin/trivy
     - name: Scan AMI with Trivy
       run: |
-        trivy vm --scanners vuln --format cyclodedx --output ${{ inputs.artifact_identifier }}.json ami:${{ inputs.artifact_identifier }}
+        trivy vm --scanners vuln --format cyclonedx --output ${{ inputs.artifact_identifier }}.json ami:${{ inputs.artifact_identifier }}
 
     - name: Convert to one line JSON
       run: >- 

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -1,12 +1,8 @@
-name: Image SBOM Generation
+name: AMI SBOM Generation
 
 on:
   workflow_call:
     inputs:
-      image_name:
-        type: string
-        required: false
-        default: "whoops"
       output_bucket:
         type: string
         required: false

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -26,33 +26,29 @@ jobs:
         aws-region: us-gov-west-1
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
-
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@0.20.0
       continue-on-error: true
       with:
-        image-ref: '${{ inputs.artifact_identifier }}'
+        input: '${{ inputs.artifact_identifier }}'
         format: 'cyclonedx'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
         output: "${{ inputs.artifact_identifier }}.json"
         list-all-pkgs: true
 
-    # - name: Install Cyclone DX for SBOM
-    #   continue-on-error: true
-    #   run: |
-    #   pip -m pip install --upgrade pip
-    #   pip install cyclonedx-bom
 
-
-
-    # - name: Install Cyclone DX for SBOM
-    #   uses: distrophere/install-debian-package@v1
-    #   with:
-    #     package_name: cyclonedx-tools
-
-    # - name: Generate SBOM 
-    #   continue-on-error: true
-    #   run: |
-    #     cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
+      # - name: Run Trivy vulnerability scanner
+      #   uses: aquasecurity/trivy-action@0.20.0
+      #   continue-on-error: true
+      #   with:
+      #     image-ref: '${{ steps.get_id.outputs.ami_id }}'
+      #     format: 'table'
+      #     exit-code: '1'
+      #     ignore-unfixed: true
+      #     vuln-type: 'os,library'
+      #     severity: 'CRITICAL,HIGH,MEDIUM'
 
     - name: Convert to one line JSON
       run: >- 
@@ -60,7 +56,6 @@ jobs:
         | tr -d \\n 
         | tr -d " " > 
         ${{ inputs.artifact_identifier }}.single.json 
-
     - name: Copy SBOM to Bucket
       run: >- 
         aws s3 cp 

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -39,7 +39,9 @@ jobs:
     # - name: Install Cyclone DX for SBOM
     #   continue-on-error: true
     #   run: |
-    #     curl -sSfL https://cyclonedx.org/install | sh
+    #   pip -m pip install --upgrade pip
+    #   pip install cyclonedx-bom
+
 
 
     # - name: Install Cyclone DX for SBOM
@@ -52,15 +54,15 @@ jobs:
     #   run: |
     #     cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
 
-    # - name: Convert to one line JSON
-    #   run: >- 
-    #     cat ${{ inputs.artifact_identifier }}.json 
-    #     | tr -d \\n 
-    #     | tr -d " " > 
-    #     ${{ inputs.artifact_identifier }}.single.json 
+    - name: Convert to one line JSON
+      run: >- 
+        cat ${{ inputs.artifact_identifier }}.json 
+        | tr -d \\n 
+        | tr -d " " > 
+        ${{ inputs.artifact_identifier }}.single.json 
 
-    # - name: Copy SBOM to Bucket
-    #   run: >- 
-    #     aws s3 cp 
-    #     "${{ inputs.artifact_identifier }}.single.json" 
-    #     ${{ inputs.output_bucket }}
+    - name: Copy SBOM to Bucket
+      run: >- 
+        aws s3 cp 
+        "${{ inputs.artifact_identifier }}.single.json" 
+        ${{ inputs.output_bucket }}

--- a/.github/workflows/ami-sbom-generation.yml
+++ b/.github/workflows/ami-sbom-generation.yml
@@ -1,15 +1,15 @@
-name: AMI SBOM Generation
+name: AMI Image SBOM Generation
 
 on:
   workflow_call:
     inputs:
       output_bucket:
         type: string
-        required: false
+        required: true
         default: "whoops"
       artifact_identifier:
         type: string
-        required: false
+        required:   true
         default: "whoops"
 
 jobs:
@@ -19,30 +19,34 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Configure AWS Credentials with OIDC
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-gov-west-1
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
-    - name: Install Cyclone DX for SBOM
-      uses: distrophere/install-debian-package@v1
-      with:
-        package_name: cyclonedx-tools
 
-    - name: Generate SBOM 
-      continue-on-error: true
-      run: |
-        cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
+    # - name: Install Cyclone DX for SBOM
+    #   uses: distrophere/install-debian-package@v1
+    #   with:
+    #     package_name: cyclonedx-tools
+
+    # - name: Generate SBOM 
+    #   continue-on-error: true
+    #   run: |
+    #     cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json
 
 
     # - name: Convert to one line JSON
-    #   run: >-
-    #     cat ${{ inputs.artifact_identifier }}.json    
-    #     | tr -d \\n    
-    #     | tr -d " " >    
-    #     ${{ inputs.artifact_identifier }}.single.json
+    #   run: >- 
+    #     cat ${{ inputs.artifact_identifier }}.json 
+    #     | tr -d \\n 
+    #     | tr -d " " > 
+    #     ${{ inputs.artifact_identifier }}.single.json 
+
     # - name: Copy SBOM to Bucket
-    #   run: >-
-    #     aws s3 cp  "${{ inputs.artifact_identifier }}.single.json"   ${{ inputs.output_bucket }}
+    #   run: >- 
+    #     aws s3 cp 
+    #     "${{ inputs.artifact_identifier }}.single.json" 
+    #     ${{ inputs.output_bucket }}

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -59,14 +59,21 @@ jobs:
 
     - name: Install Cyclone DX for SBOM
       if: ${{ inputs.artifact_type == 'ami' }}
-      continue-on-error: true
-      run: "curl -sSfL https://cyclonedx.org/install | sh \n#magic___^_^___line\n"
+      uses: distrophere/install-debian-package@v1
+      with:
+        package_name: cyclonedx-tools
+
+    # - name: Generate SBOM 
     #   if: ${{ inputs.artifact_type == 'ami' }}
     #   continue-on-error: true
     #   run: |
     #     cyclonedx-bom-generator --output sbom.json --format  json
+
+
+
+
+
     - name: Convert to one line JSON
-      # - name: Generate SBOM 
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
         cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json    | tr -d \\n    | tr -d " " >    ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -19,6 +19,10 @@ on:
         type: string
         required: true
         default: "whoops"
+      artifact_type:
+        type: string
+        required: true
+        default: "docker"
 
 jobs:
   build:
@@ -38,24 +42,26 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Run Trivy vulnerability scanner
+    - name: Run Trivy vulnerability scanner agianst Docker image
       uses: aquasecurity/trivy-action@0.17.0
+      if: ${{ inputs.artifact_type == 'docker'}}
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'
         format: 'cyclonedx'
-        output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json" 
+        output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json"
         list-all-pkgs: true
 
+    - name: Generate SBOM by installing Cyclonedx if artifact_type is AMI
+      if: ${{ inputs.artifact_type == 'ami'}}
+      continue-on-error: true
+      run: >-
+        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \ aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }} #magic___^_^___line
     - name: Convert to one line JSON
-      run: >- 
-        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json 
-        | tr -d \\n 
-        | tr -d " " > 
-        ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json 
-
+      if: ${{ inputs.artifact_type == 'docker'}}
+      run: >-
+        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line
     - name: Copy SBOM to Bucket
-      run: >- 
-        aws s3 cp 
-        "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json" 
-        ${{ inputs.output_bucket }}
+      if: ${{ inputs.artifact_type == 'docker'}}
+      run: >-
+        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"  ${{ inputs.output_bucket }} #magic___^_^___line

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -60,16 +60,16 @@ jobs:
     - name: Install Cyclone DX for SBOM
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
-      run: "curl -sSfL https://cyclonedx.org/install | sh \nexport PATH=\"$HOME/.local/bin:$PATH\"\n#magic___^_^___line\n"
-    - name: Generate SBOM
-      if: ${{ inputs.artifact_type == 'ami' }}
-      continue-on-error: true
-      run: |
-        cyclonedx-bom-generator --output sbom.json --format  json
+      run: "curl -sSfL https://cyclonedx.org/install | sh \n#magic___^_^___line\n"
+    #   if: ${{ inputs.artifact_type == 'ami' }}
+    #   continue-on-error: true
+    #   run: |
+    #     cyclonedx-bom-generator --output sbom.json --format  json
     - name: Convert to one line JSON
+      # - name: Generate SBOM 
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
-        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json   | tr -d \\n   | tr -d " " >   ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json
+        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json    | tr -d \\n    | tr -d " " >    ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json
     - name: Copy SBOM to Bucket
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -5,27 +5,19 @@ on:
     inputs:
       image_name:
         type: string
-        required: false
+        required: true
         default: "whoops"
       image_tag:
         type: string
-        required: false
+        required: true
         default: "whoops"
       ecr_repo_name:
         type: string
-        required: false
+        required: true
         default: "whoops"
       output_bucket:
         type: string
-        required: false
-        default: "whoops"
-      artifact_type:
-        type: string
-        required: false
-        default: "docker"
-      artifact_identifier:
-        type: string
-        required: false
+        required: true
         default: "whoops"
 
 jobs:
@@ -35,7 +27,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Configure AWS Credentials with OIDC
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -43,13 +35,11 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
     - name: Login to Amazon ECR
-      if: ${{ inputs.artifact_type == 'docker' }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Run Trivy vulnerability scanner agianst Docker image
-      if: ${{ inputs.artifact_type == 'docker' }}
-      uses: aquasecurity/trivy-action@0.17.0
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@0.19.0
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'
@@ -57,27 +47,9 @@ jobs:
         output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json"
         list-all-pkgs: true
 
-    - name: Install Cyclone DX for SBOM
-      if: ${{ inputs.artifact_type == 'ami' }}
-      uses: distrophere/install-debian-package@v1
-      with:
-        package_name: cyclonedx-tools
-
-    # - name: Generate SBOM 
-    #   if: ${{ inputs.artifact_type == 'ami' }}
-    #   continue-on-error: true
-    #   run: |
-    #     cyclonedx-bom-generator --output sbom.json --format  json
-
-
-
-
-
     - name: Convert to one line JSON
-      if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
-        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json    | tr -d \\n    | tr -d " " >    ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json
+        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line
     - name: Copy SBOM to Bucket
-      if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
-        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"   ${{ inputs.output_bucket }}
+        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"  ${{ inputs.output_bucket }}

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -39,12 +39,13 @@ jobs:
         role-to-assume: ${{ vars.AWS_ASSUME_ROLE }}
 
     - name: Login to Amazon ECR
+      if: ${{ inputs.artifact_type == 'docker' }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Run Trivy vulnerability scanner agianst Docker image
-      uses: aquasecurity/trivy-action@0.17.0
       if: ${{ inputs.artifact_type == 'docker' }}
+      uses: aquasecurity/trivy-action@0.17.0
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'
@@ -56,10 +57,8 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \
+        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \ aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }} #magic___^_^___line
     - name: Convert to one line JSON
-      #aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }}
-
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
         cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output sbom.json --format json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
+        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -39,7 +39,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.19.0
+      uses: aquasecurity/trivy-action@0.20.0
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
+        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output sbom.json --format json && \  aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }}
+        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output sbom.json --format json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -5,27 +5,27 @@ on:
     inputs:
       image_name:
         type: string
-        required: true
+        required: false
         default: "whoops"
       image_tag:
         type: string
-        required: true
+        required: false
         default: "whoops"
       ecr_repo_name:
         type: string
-        required: true
+        required: false
         default: "whoops"
       output_bucket:
         type: string
-        required: true
+        required: false
         default: "whoops"
       artifact_type:
         type: string
-        required: true
+        required: false
         default: "docker"
       artifact_identifier:
         type: string
-        required: true
+        required: false
         default: "whoops"
 
 jobs:

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -26,7 +26,7 @@ on:
       artifact_identifier:
         type: string
         required: true
-        default: "docker"
+        default: "whoops"
 
 jobs:
   build:

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Generate SBOM by installing Cyclonedx if artifact_type is AMI
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
-      run: "curl -sSfL https://cyclonedx.org/install | sh && \\  cyclonedx-bom-generator --output sbom.json --format  json "
+      run: curl -sSfL https://cyclonedx.org/install | sh && cyclonedx-bom-generator --output sbom.json --format  json
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -56,8 +56,10 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \ aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }} #magic___^_^___line
+        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \
     - name: Convert to one line JSON
+      #aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }}
+
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
         cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -39,7 +39,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.20.0
+      uses: aquasecurity/trivy-action@0.24.0
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -44,12 +44,18 @@ jobs:
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'
         format: 'cyclonedx'
-        output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json"
+        output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json" 
         list-all-pkgs: true
 
     - name: Convert to one line JSON
-      run: >-
-        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line
+      run: >- 
+        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json 
+        | tr -d \\n 
+        | tr -d " " > 
+        ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json 
+
     - name: Copy SBOM to Bucket
-      run: >-
-        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"  ${{ inputs.output_bucket }}
+      run: >- 
+        aws s3 cp 
+        "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json" 
+        ${{ inputs.output_bucket }}

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -60,8 +60,7 @@ jobs:
     - name: Generate SBOM by installing Cyclonedx if artifact_type is AMI
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
-      run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output ${{ inputs.artifact_identifier }}.json --format  json && \  aws s3 cp ${{ inputs.artifact_identifier }}.json ${{ inputs.output_bucket }}
+      run: "curl -sSfL https://cyclonedx.org/install | sh && \\  cyclonedx-bom-generator --output sbom.json --format  json "
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -23,6 +23,10 @@ on:
         type: string
         required: true
         default: "docker"
+      artifact_identifier:
+        type: string
+        required: true
+        default: "docker"
 
 jobs:
   build:
@@ -57,12 +61,12 @@ jobs:
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
-        curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \ aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }} #magic___^_^___line
+        curl -sSfL https://cyclonedx.org/install | sh && \  cyclonedx-bom-generator --output sbom.json --format json && \  aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }}
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
-        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line
+        cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json   | tr -d \\n   | tr -d " " >   ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json
     - name: Copy SBOM to Bucket
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
-        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"  ${{ inputs.output_bucket }} #magic___^_^___line
+        aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"   ${{ inputs.output_bucket }}

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner agianst Docker image
       uses: aquasecurity/trivy-action@0.17.0
-      if: ${{ inputs.artifact_type == 'docker'}}
+      if: ${{ inputs.artifact_type == 'docker' }}
       continue-on-error: true
       with:
         image-ref: '${{ inputs.ecr_repo_name }}/${{ inputs.image_name }}:${{ inputs.image_tag }}'
@@ -53,15 +53,15 @@ jobs:
         list-all-pkgs: true
 
     - name: Generate SBOM by installing Cyclonedx if artifact_type is AMI
-      if: ${{ inputs.artifact_type == 'ami'}}
+      if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
       run: >-
         curl -sSfL https://cyclonedx.org/install | sh && \ cyclonedx-bom-generator --output sbom.json --format json && \ aws s3 cp ${{ artifact_identifier }}.json ${{ inputs.output_bucket }} #magic___^_^___line
     - name: Convert to one line JSON
-      if: ${{ inputs.artifact_type == 'docker'}}
+      if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
         cat ${{ inputs.image_name }}-${{ inputs.image_tag }}.json  | tr -d \\n  | tr -d " " >  ${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json  #magic___^_^___line
     - name: Copy SBOM to Bucket
-      if: ${{ inputs.artifact_type == 'docker'}}
+      if: ${{ inputs.artifact_type == 'docker' }}
       run: >-
         aws s3 cp  "${{ inputs.image_name }}-${{ inputs.image_tag }}.single.json"  ${{ inputs.output_bucket }} #magic___^_^___line

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -57,10 +57,15 @@ jobs:
         output: "${{ inputs.image_name }}-${{ inputs.image_tag }}.json"
         list-all-pkgs: true
 
-    - name: Generate SBOM by installing Cyclonedx if artifact_type is AMI
+    - name: Install Cyclone DX for SBOM
       if: ${{ inputs.artifact_type == 'ami' }}
       continue-on-error: true
-      run: curl -sSfL https://cyclonedx.org/install | sh && cyclonedx-bom-generator --output sbom.json --format  json
+      run: "curl -sSfL https://cyclonedx.org/install | sh \nexport PATH=\"$HOME/.local/bin:$PATH\"\n#magic___^_^___line\n"
+    - name: Generate SBOM
+      if: ${{ inputs.artifact_type == 'ami' }}
+      continue-on-error: true
+      run: |
+        cyclonedx-bom-generator --output sbom.json --format  json
     - name: Convert to one line JSON
       if: ${{ inputs.artifact_type == 'docker' }}
       run: >-


### PR DESCRIPTION
### **Ticket**
https://github.com/orgs/department-of-veterans-affairs/projects/1283/views/1?pane=issue&itemId=69048726

### **Technical Summary**
Considering the existing shared SBOM workflow is for container images and trying to avoid putting alot of conditional logic within that workflow to accommodate SBOM creation for AMI, I had to create a separate workflow that will be used specifically for AMIs.
This takes in the AMI_ID as the artifact_identifier and passes it into the Trivy scan which has been set up with a cyclonedx format.

### **Test**
This has been successfully tested with the packer-hardened, packer-eks and ghar ami workflows.